### PR TITLE
Make sure to append 'columns' and 'rows' nodes to the xml even if data is empty

### DIFF
--- a/Persistence/Legacy/Content/FieldValue/Converter/Matrix.php
+++ b/Persistence/Legacy/Content/FieldValue/Converter/Matrix.php
@@ -213,6 +213,18 @@ class Matrix implements Converter
 
         $root->appendChild( $doc->createElement( 'name' ) );
 
+        if (!isset($matrixValue['columns'])) {
+            $columns = $doc->createElement( 'columns' );
+            $columns->setAttribute( 'number', 0 );
+            $root->appendChild( $columns );
+
+            $rowsNode = $doc->createElement( 'rows' );
+            $rowsNode->setAttribute( 'number', 0 );
+            $root->appendChild( $rowsNode );
+
+            return $doc->saveXML();
+        }
+
         $columns = $doc->createElement( 'columns' );
         $columns->setAttribute( 'number', count( $matrixValue['columns'] ) );
 


### PR DESCRIPTION
If the data was empty (eg. when using Kaliop migrations to add the field), the converter would fail due to the usage of the unset value.
This makes sure the proper xml is generated even if no data is provided.